### PR TITLE
fix: remove invalid imports from unavailable context(Auth and Folder)

### DIFF
--- a/src/components/UI/CreateFolder.tsx
+++ b/src/components/UI/CreateFolder.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from "react";
 import { gql, useMutation } from "@apollo/client";
-import { Folder } from "../../context/Folder";
+import { Folder } from "../../store/reducers/folder";
 import { addNewFolder } from "../../store/actions/folder";
 import { useDispatch, useSelector } from "react-redux";
 

--- a/src/components/UI/FindFolderByOwnerId.tsx
+++ b/src/components/UI/FindFolderByOwnerId.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import { gql, useQuery } from "@apollo/client";
-import { useAuth, Auth } from "../../context/Auth";
+import { Auth } from "../../store/reducers/auth";
 import { useDispatch } from "react-redux";
 import { updateFolders } from "../../store/actions/folder";
 import { useSelector } from "react-redux";


### PR DESCRIPTION
Invalid imports as a result of removing hooks in Auth.tsx and Folder.tsx